### PR TITLE
Fixing Dice So Nice integration with Blades rolls

### DIFF
--- a/module/blades-roll.js
+++ b/module/blades-roll.js
@@ -125,7 +125,7 @@ async function showChatRollMessage(r, zeromode, attribute_name = "", position = 
   let messageData = {
     speaker: speaker,
     content: result,
-    roll: r
+    rolls: [r],
   }
 
   ChatMessage.create(messageData);


### PR DESCRIPTION
Looks like taking out the deprecated chat message type breaks Dice So Nice integration. Sending the roll in an array in the 'rolls' property of the message data object appears to work, however.