### PR TITLE
Initialize dice roller dialog from action rating click to show base number of dice in dropdown

### DIFF
--- a/module/blades-actor.js
+++ b/module/blades-actor.js
@@ -66,10 +66,16 @@ export class BladesActor extends Actor {
 
   /* -------------------------------------------- */
 
-  rollAttributePopup(attribute_name) {
+  rollAttributePopup(attribute_name, defaultDice = 0) {
 
     // const roll = new Roll("1d20 + @abilities.wis.mod", actor.getRollData());
     let attribute_label = BladesHelpers.getRollLabel(attribute_name);
+
+    const sanitizedDefaultDice = (() => {
+      const numeric = Number(defaultDice);
+      if (Number.isNaN(numeric)) return 0;
+      return Math.max(0, Math.min(Math.floor(numeric), 10));
+    })();
 
     // get crew tier info from character sheet if available
     let current_tier = 0;
@@ -160,7 +166,10 @@ export class BladesActor extends Actor {
             <span style="width:200px">
               <label>${game.i18n.localize("BITD.RollNumberOfDice")}:</label>
               <select id="qty" name="qty">
-                ${Array(11).fill().map((item, i) => `<option value="${i}">${i}d</option>`).join('')}
+                ${Array.from({ length: 11 }, (_, i) => {
+                  const selected = i === sanitizedDefaultDice ? " selected" : "";
+                  return `<option value="${i}"${selected}>${i}d</option>`;
+                }).join("")}
               </select>
             </span>
           </div>

--- a/module/blades-sheet.js
+++ b/module/blades-sheet.js
@@ -48,7 +48,21 @@ export class BladesSheet extends ActorSheet {
       html.on("change", "textarea", this._onChangeInput.bind(this));  // Use delegated listener on the form
     }
 
-    html.find(".roll-die-attribute").click(this._onRollAttributeDieClick.bind(this));
+    html.find(".roll-die-attribute").click((event) => {
+      const attributeName = event.currentTarget?.dataset?.rollAttribute;
+      let defaultDice = 0;
+      try {
+        const rollData = this.actor.getRollData?.();
+        defaultDice = Number(rollData?.dice_amount?.[attributeName] ?? 0);
+      } catch (err) {
+        console.warn("Failed to determine dice amount for roll.", err);
+        defaultDice = 0;
+      }
+
+      const sanitizedDice = Number.isNaN(defaultDice) ? 0 : defaultDice;
+
+      this.actor.rollAttributePopup(attributeName, sanitizedDice);
+    });
 	
     // Update Inventory Item
     html.find('.item-body').click(ev => {


### PR DESCRIPTION
Initialize dice roller dialog from action rating click to show base number of dice in dropdown

Feature summary

  - Action rating roll dialog opens pre-filled with the dots number of dice. It was rolling the right number, but my players got confused that the roll dialog said 0d.

   Implementation notes

    - module/blades-sheet.js:60 inspects the actor’s dice_amount for the clicked attribute using getRollData(), sanitizes it (falls back to 0 if missing/NaN), and passes that value into rollAttributePopup.
    - module/blades-actor.js:75 accepts the optional default, clamps it into the dialog’s existing 0–10 range, and pre-selects the matching <option>. Other callers (without a default) retain the original zero-filled behavior.
    - Error handling is unchanged: if the sheet can’t figure out the dice count, log a warning and revert to zero to keep the dialog working
    - Compatibility: the crew-tier PR branch submitted separately includes the same method signature and sanitized dropdown logic, so either or both PRs can merge