### PR TITLE
Fix #43: migrate system sheets to namespaced Foundry APIs

### DIFF
--- a/module/blades-actor-sheet.js
+++ b/module/blades-actor-sheet.js
@@ -1,6 +1,7 @@
 import {BladesSheet} from "./blades-sheet.js";
 import {BladesActiveEffect} from "./blades-active-effect.js";
 import {BladesHelpers} from "./blades-helpers.js";
+import { enrichHTML } from "./compat.js";
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -90,7 +91,7 @@ export class BladesActorSheet extends BladesSheet {
             };
         }
 
-        sheetData.system.description = await TextEditor.enrichHTML(sheetData.system.description, {
+        sheetData.system.description = await enrichHTML(sheetData.system.description, {
             secrets: sheetData.owner,
             async: true
         });

--- a/module/blades-helpers.js
+++ b/module/blades-helpers.js
@@ -1,3 +1,5 @@
+import { generateRandomId } from "./compat.js";
+
 export class BladesHelpers {
 
   /**
@@ -47,7 +49,7 @@ export class BladesHelpers {
     const item_type = a.dataset.itemType;
 
     let data = {
-      name: randomID(),
+      name: generateRandomId(),
       type: item_type
     };
     return actor.createEmbeddedDocuments("Item", [data]);
@@ -310,7 +312,7 @@ export class BladesHelpers {
             callback: async (html) => {
               const form = html.find('form')[0];
               const newContact = {
-                id: foundry.utils.randomID(),
+                id: generateRandomId(),
                 name: form.name.value,
                 description_short: form.description_short.value,
                 standing: form.standing.value

--- a/module/blades-item-sheet.js
+++ b/module/blades-item-sheet.js
@@ -4,8 +4,11 @@
  */
 import {onManageActiveEffect, prepareActiveEffectCategories} from "./effects.js";
 import { BladesActiveEffect } from "./blades-active-effect.js";
+import { getItemSheetClass, enrichHTML } from "./compat.js";
 
-export class BladesItemSheet extends ItemSheet {
+const BaseItemSheet = getItemSheetClass();
+
+export class BladesItemSheet extends BaseItemSheet {
 
   /** @override */
 	static get defaultOptions() {
@@ -62,7 +65,7 @@ export class BladesItemSheet extends ItemSheet {
     // Prepare Active Effects
     sheetData.effects = prepareActiveEffectCategories(this.document.effects);
 
-    sheetData.system.description = await TextEditor.enrichHTML(sheetData.system.description, {secrets: sheetData.owner, async: true});
+    sheetData.system.description = await enrichHTML(sheetData.system.description, {secrets: sheetData.owner, async: true});
 
     return sheetData;
   }

--- a/module/blades-item.js
+++ b/module/blades-item.js
@@ -1,4 +1,5 @@
 import { BladesHelpers } from "./blades-helpers.js";
+import { renderHandlebarsTemplate as renderTemplate } from "./compat.js";
 
 /**
  * Extend the basic Item

--- a/module/blades-npc-sheet.js
+++ b/module/blades-npc-sheet.js
@@ -1,5 +1,6 @@
 
 import { BladesSheet } from "./blades-sheet.js";
+import { enrichHTML } from "./compat.js";
 
 /**
  * @extends {BladesSheet}
@@ -28,7 +29,7 @@ export class BladesNPCSheet extends BladesSheet {
     sheetData.owner = superData.owner;
     sheetData.editable = superData.editable;
 
-    sheetData.system.description = await TextEditor.enrichHTML(sheetData.system.description, {secrets: sheetData.owner, async: true});
+    sheetData.system.description = await enrichHTML(sheetData.system.description, {secrets: sheetData.owner, async: true});
 
     return sheetData;
   }

--- a/module/blades-roll.js
+++ b/module/blades-roll.js
@@ -1,3 +1,5 @@
+import { renderHandlebarsTemplate as renderTemplate } from "./compat.js";
+
 /**
  * Roll Dice.
  * @param {int} dice_amount

--- a/module/blades-sheet.js
+++ b/module/blades-sheet.js
@@ -1,12 +1,15 @@
 import { BladesActiveEffect } from "./blades-active-effect.js";
 import { BladesHelpers } from "./blades-helpers.js";
+import { getActorSheetClass } from "./compat.js";
+
+const BaseActorSheet = getActorSheetClass();
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
  * @extends {ActorSheet}
  */
 
-export class BladesSheet extends ActorSheet {
+export class BladesSheet extends BaseActorSheet {
 
   /* -------------------------------------------- */
 

--- a/module/blades-templates.js
+++ b/module/blades-templates.js
@@ -3,6 +3,8 @@
  * Pre-loaded templates are compiled and cached for fast access when rendering
  * @return {Promise}
  */
+import { loadHandlebarsTemplates } from "./compat.js";
+
 export const preloadHandlebarsTemplates = async function() {
 
   // Define template paths to load
@@ -18,5 +20,5 @@ export const preloadHandlebarsTemplates = async function() {
   ];
 
   // Load the template parts
-  return loadTemplates(templatePaths);
+  return loadHandlebarsTemplates(templatePaths);
 };

--- a/module/compat.js
+++ b/module/compat.js
@@ -1,0 +1,96 @@
+/**
+ * Lightweight compatibility helpers that prefer the V13+ namespaced APIs while
+ * keeping graceful fallbacks for the V11/V12 globals this system still
+ * supports. Each accessor resolves the modern entry point first so the module
+ * avoids deprecation warnings once the legacy globals disappear (planned for
+ * Foundry VTT V15+).
+ */
+export function getActorSheetClass() {
+  return foundry?.appv1?.sheets?.ActorSheet ?? globalThis.ActorSheet;
+}
+
+export function getItemSheetClass() {
+  return foundry?.appv1?.sheets?.ItemSheet ?? globalThis.ItemSheet;
+}
+
+let cachedSheetConfig;
+
+function getSheetConfig() {
+  if (cachedSheetConfig) return cachedSheetConfig;
+  const apiConfig = foundry?.applications?.api?.DocumentSheetConfig ?? foundry?.applications?.config?.DocumentSheetConfig;
+  cachedSheetConfig = apiConfig ?? null;
+  return cachedSheetConfig;
+}
+
+function getActorsCollectionLegacy() {
+  return foundry?.documents?.collections?.Actors ?? game?.actors ?? globalThis.Actors;
+}
+
+function getItemsCollectionLegacy() {
+  return foundry?.documents?.collections?.Items ?? game?.items ?? globalThis.Items;
+}
+
+export function unregisterActorSheet(namespace, sheetClass) {
+  const sheetConfig = getSheetConfig();
+  if (sheetConfig?.unregisterSheet) {
+    return sheetConfig.unregisterSheet(CONFIG.Actor.documentClass, namespace, sheetClass);
+  }
+  return getActorsCollectionLegacy()?.unregisterSheet?.(namespace, sheetClass);
+}
+
+export function registerActorSheet(namespace, sheetClass, options) {
+  const sheetConfig = getSheetConfig();
+  if (sheetConfig?.registerSheet) {
+    return sheetConfig.registerSheet(CONFIG.Actor.documentClass, namespace, sheetClass, options);
+  }
+  return getActorsCollectionLegacy()?.registerSheet?.(namespace, sheetClass, options);
+}
+
+export function unregisterItemSheet(namespace, sheetClass) {
+  const sheetConfig = getSheetConfig();
+  if (sheetConfig?.unregisterSheet) {
+    return sheetConfig.unregisterSheet(CONFIG.Item.documentClass, namespace, sheetClass);
+  }
+  return getItemsCollectionLegacy()?.unregisterSheet?.(namespace, sheetClass);
+}
+
+export function registerItemSheet(namespace, sheetClass, options) {
+  const sheetConfig = getSheetConfig();
+  if (sheetConfig?.registerSheet) {
+    return sheetConfig.registerSheet(CONFIG.Item.documentClass, namespace, sheetClass, options);
+  }
+  return getItemsCollectionLegacy()?.registerSheet?.(namespace, sheetClass, options);
+}
+
+export function loadHandlebarsTemplates(paths) {
+  const loader = foundry?.applications?.handlebars?.loadTemplates ?? globalThis.loadTemplates;
+  if (!loader) {
+    throw new Error("Unable to resolve a Handlebars template loader");
+  }
+  return loader(paths);
+}
+
+export function renderHandlebarsTemplate(...args) {
+  const renderer = foundry?.applications?.handlebars?.renderTemplate ?? globalThis.renderTemplate;
+  if (!renderer) {
+    throw new Error("Unable to resolve a Handlebars template renderer");
+  }
+  return renderer(...args);
+}
+
+export function enrichHTML(...args) {
+  const textEditor = foundry?.applications?.ux?.TextEditor?.implementation ?? globalThis.TextEditor;
+  const enrich = textEditor?.enrichHTML;
+  if (!enrich) {
+    throw new Error("Unable to resolve TextEditor.enrichHTML");
+  }
+  return enrich.apply(textEditor, args);
+}
+
+export function generateRandomId() {
+  const randomIdFn = foundry?.utils?.randomID ?? globalThis.randomID;
+  if (!randomIdFn) {
+    throw new Error("Unable to resolve a randomID generator");
+  }
+  return randomIdFn();
+}


### PR DESCRIPTION
Here's a potential fix for issue #43 to clear out the Foundry v13+ deprecation warnings while keeping the system working back v11. I tested on v13. In my experiments the system loads without deprecation warnings.

  ### Summary

  - Introduced module/compat.js, a small shim that always prefers the new namespaced APIs (sheets, collections, Handlebars helpers, TextEditor, randomID) and falls back on legacy globals in older versions
  - Moved sheet registration into the ready hook because the new stuff may not exist before then
  - Routed “global” calls through the compat helpers (sheet subclasses, chat renderers, template preload, random ID generation)
  - Added comments in compat.js to document the approach