### PR TITLE
Enable getAllItemsByType to handle more than one Compendium

### DIFF
--- a/module/blades-helpers.js
+++ b/module/blades-helpers.js
@@ -101,11 +101,11 @@ export class BladesHelpers {
     }
 
     if (item_type != "crew") {
-      let pack = game.packs.find(e => e.metadata.name === item_type);
-      let compendium_content = await pack.getDocuments();
-      compendium_items = compendium_content.map(e => {
-        return e
-      });
+      let packs = game.packs.filter(e => e.metadata.name === item_type);
+      let compendium_contents = await Promise.all(packs.map(pack => pack.getDocuments()));
+      for(const compendium_content of compendium_contents) {
+        compendium_items = compendium_items.concat(compendium_content)
+      }
       list_of_items = world_items.concat(compendium_items);
     } else {
       list_of_items = world_items;


### PR DESCRIPTION
During trying to set up a flavor module for Blades in the Dark, I noticed the system would only ever consider one Compendium per type for building the lists of select able Items.

This enables the getAllItemsByType function to work with all packs matching the name, instead of only the first.