### PR TITLE
Fix the alignment of roll dialog options

### DIFF
--- a/module/blades-actor.js
+++ b/module/blades-actor.js
@@ -131,18 +131,19 @@ export class BladesActor extends Actor {
 		}
 		// Row 3: Other roll types
 		content += `
-          <div style="display:grid; grid-template-columns:auto auto; gap:0.4em 1em;">
-            <div style="display:grid; gap:0.4em;">
-              <label><input type="radio" id="fortune" name="rollSelection" value="fortune"> ${game.i18n.localize("BITD.Fortune")}</label>
-              <label><input type="radio" id="gatherInfo" name="rollSelection" value="gatherInfo"> ${game.i18n.localize("BITD.GatherInformation")}</label>
-              <label><input type="radio" id="indulgeVice" name="rollSelection" value="indulgeVice"> ${game.i18n.localize("BITD.IndulgeVice")}</label>
-              <label><input type="radio" id="engagement" name="rollSelection" value="engagement"> ${game.i18n.localize("BITD.Engagement")}</label>
-              <label><input type="radio" id="acquireAsset" name="rollSelection" value="acquireAsset"> ${game.i18n.localize("BITD.AcquireAsset")}</label>
-            </div>
-            <div style="display:grid; gap:0.4em; align-content:end;">
-              <span><label>${game.i18n.localize("BITD.RollNumberOfDice")}:</label> <select id="qty" name="qty">${Array.from({ length: 11 }, (_, i) => { const selected = i === sanitizedDefaultDice ? " selected" : ""; return `<option value="${i}"${selected}>${i}d</option>`; }).join("")}</select></span>
-              <span><label>${game.i18n.localize('BITD.CrewTier')}:</label> <select id="tier" name="tier"><option value="${current_tier}" selected disabled hidden>${current_tier}</option>${Array(5).fill().map((item, i) => `<option value="${i}">${i}</option>`).join('')}</select></span>
-            </div>
+          <div style="display:grid; grid-template-columns:auto auto auto; column-gap:0.5em; row-gap:0.4em; align-items:center;">
+            <label><input type="radio" id="fortune" name="rollSelection" value="fortune"> ${game.i18n.localize("BITD.Fortune")}</label>
+            <span style="grid-column:2 / 4;"></span>
+            <label><input type="radio" id="gatherInfo" name="rollSelection" value="gatherInfo"> ${game.i18n.localize("BITD.GatherInformation")}</label>
+            <span style="grid-column:2 / 4;"></span>
+            <label><input type="radio" id="indulgeVice" name="rollSelection" value="indulgeVice"> ${game.i18n.localize("BITD.IndulgeVice")}</label>
+            <span style="grid-column:2 / 4;"></span>
+            <label><input type="radio" id="engagement" name="rollSelection" value="engagement"> ${game.i18n.localize("BITD.Engagement")}</label>
+            <label style="margin:0; justify-self:end; white-space:nowrap;">${game.i18n.localize("BITD.RollNumberOfDice")}:</label>
+            <select id="qty" name="qty" style="width:auto; min-width:4.5em; justify-self:start;">${Array.from({ length: 11 }, (_, i) => { const selected = i === sanitizedDefaultDice ? " selected" : ""; return `<option value="${i}"${selected}>${i}d</option>`; }).join("")}</select>
+            <label><input type="radio" id="acquireAsset" name="rollSelection" value="acquireAsset"> ${game.i18n.localize("BITD.AcquireAsset")}</label>
+            <label style="margin:0; justify-self:end; white-space:nowrap;">${game.i18n.localize('BITD.CrewTier')}:</label>
+            <select id="tier" name="tier" style="width:auto; min-width:4.5em; justify-self:start;"><option value="${current_tier}" selected disabled hidden>${current_tier}</option>${Array(5).fill().map((item, i) => `<option value="${i}">${i}</option>`).join('')}</select>
           </div>
         </fieldset>
             `;

--- a/module/blades-roll.js
+++ b/module/blades-roll.js
@@ -387,18 +387,19 @@ export async function simpleRollPopup() {
         </div>
         <fieldset class="form-group">
           <legend>Roll Types</legend>
-          <div style="display:grid; grid-template-columns:auto auto; gap:1em;">
-            <div style="display:grid; gap:0.4em;">
-              <label><input type="radio" id="fortune" name="rollSelection" value="fortune" checked=true> ${game.i18n.localize("BITD.Fortune")}</label>
-              <label><input type="radio" id="gatherInfo" name="rollSelection" value="gatherInfo"> ${game.i18n.localize("BITD.GatherInformation")}</label>
-              <label><input type="radio" id="engagement" name="rollSelection" value="engagement"> ${game.i18n.localize("BITD.Engagement")}</label>
-              <label><input type="radio" id="indulgeVice" name="rollSelection" value="indulgeVice"> ${game.i18n.localize("BITD.IndulgeVice")}</label>
-              <label><input type="radio" id="acquireAsset" name="rollSelection" value="acquireAsset"> ${game.i18n.localize("BITD.AcquireAsset")}</label>
-            </div>
-            <div style="display:grid; gap:0.4em; align-content:end;">
-              <span><label>${game.i18n.localize('BITD.Stress')}:</label> <select id="stress" name="stress"><option value="${current_stress}" selected disabled hidden>${current_stress}</option>${Array(11).fill().map((item, i) => `<option value="${i}">${i}</option>`).join('')}</select></span>
-              <span><label>${game.i18n.localize('BITD.CrewTier')}:</label> <select id="tier" name="tier"><option value="${current_tier}" selected disabled hidden>${current_tier}</option>${Array(5).fill().map((item, i) => `<option value="${i}">${i}</option>`).join('')}</select></span>
-            </div>
+          <div style="display:grid; grid-template-columns:auto auto auto; column-gap:0.5em; row-gap:0.4em; align-items:center;">
+            <label><input type="radio" id="fortune" name="rollSelection" value="fortune" checked=true> ${game.i18n.localize("BITD.Fortune")}</label>
+            <span style="grid-column:2 / 4;"></span>
+            <label><input type="radio" id="gatherInfo" name="rollSelection" value="gatherInfo"> ${game.i18n.localize("BITD.GatherInformation")}</label>
+            <span style="grid-column:2 / 4;"></span>
+            <label><input type="radio" id="engagement" name="rollSelection" value="engagement"> ${game.i18n.localize("BITD.Engagement")}</label>
+            <span style="grid-column:2 / 4;"></span>
+            <label><input type="radio" id="indulgeVice" name="rollSelection" value="indulgeVice"> ${game.i18n.localize("BITD.IndulgeVice")}</label>
+            <label style="margin:0; justify-self:end; white-space:nowrap;">${game.i18n.localize('BITD.Stress')}:</label>
+            <select id="stress" name="stress" style="width:auto; min-width:4.5em; justify-self:start;"><option value="${current_stress}" selected disabled hidden>${current_stress}</option>${Array(11).fill().map((item, i) => `<option value="${i}">${i}</option>`).join('')}</select>
+            <label><input type="radio" id="acquireAsset" name="rollSelection" value="acquireAsset"> ${game.i18n.localize("BITD.AcquireAsset")}</label>
+            <label style="margin:0; justify-self:end; white-space:nowrap;">${game.i18n.localize('BITD.CrewTier')}:</label>
+            <select id="tier" name="tier" style="width:auto; min-width:4.5em; justify-self:start;"><option value="${current_tier}" selected disabled hidden>${current_tier}</option>${Array(5).fill().map((item, i) => `<option value="${i}">${i}</option>`).join('')}</select>
           </div>
         </fieldset>
         <div className="form-group">


### PR DESCRIPTION
This changes the layout of the other roll types in Roll dialogs from a grid of grids to a single 3x5 grid, to restore the inline alignment of the options dropdowns to their respective roll types.

My players (especially new ones) were getting mighty confused about when to actually use those dropdowns for "Number of dice" when it's presented the way it is now.

Before:
<img width="446" height="562" alt="image" src="https://github.com/user-attachments/assets/13227853-faac-4a5a-ba90-99345140345e" />

After:
<img width="454" height="588" alt="image" src="https://github.com/user-attachments/assets/c24a5709-3ce1-418e-a77a-eae967a00c98" />

After (v11):
<img width="398" height="432" alt="image" src="https://github.com/user-attachments/assets/e41a31bb-9359-4458-96fa-0704eaf9c53e" />


Simple Roll is also covered:
<img width="342" height="551" alt="image" src="https://github.com/user-attachments/assets/9f2857f6-c570-4d68-a8d7-5a1940560fc8" />

<img width="403" height="399" alt="image" src="https://github.com/user-attachments/assets/f3dc3278-9f16-4b15-be7d-39781c99bab6" />
