### PR TITLE
feat: show XP reminder on desperate action rolls

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -213,6 +213,7 @@
   "BITD.PositionControlled": "Kontrolliert",
   "BITD.PositionRisky": "Riskant",
   "BITD.PositionDesperate": "Aussichtslos",
+  "BITD.DesperateXPReminder": "Markiere 1 EP in",
   "BITD.EffectLimited": "Gering",
   "BITD.EffectStandard": "Gewöhnlich",
   "BITD.EffectGreat": "Groß",

--- a/lang/en.json
+++ b/lang/en.json
@@ -213,6 +213,7 @@
   "BITD.PositionControlled": "Controlled",
   "BITD.PositionRisky": "Risky",
   "BITD.PositionDesperate": "Desperate",
+  "BITD.DesperateXPReminder": "Mark 1 XP in",
   "BITD.EffectLimited": "Limited",
   "BITD.EffectStandard": "Standard",
   "BITD.EffectGreat": "Great",

--- a/lang/es.json
+++ b/lang/es.json
@@ -210,6 +210,7 @@
   "BITD.PositionControlled": "Controlada",
   "BITD.PositionRisky": "Arriesgada",
   "BITD.PositionDesperate": "Desesperada",
+  "BITD.DesperateXPReminder": "Anota 1 PX en",
   "BITD.EffectLimited": "Limitado",
   "BITD.EffectStandard": "Estándar",
   "BITD.EffectGreat": "Excelente",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -206,6 +206,7 @@
   "BITD.PositionControlled": "Contrôlé",
   "BITD.PositionRisky": "Risqué",
   "BITD.PositionDesperate": "Désespéré",
+  "BITD.DesperateXPReminder": "Gagnez 1 px en",
   "BITD.EffectLimited": "Limité",
   "BITD.EffectStandard": "Normal",
   "BITD.EffectGreat": "Important",

--- a/lang/it.json
+++ b/lang/it.json
@@ -212,6 +212,7 @@
   "BITD.PositionControlled": "Controllata",
   "BITD.PositionRisky": "Rischiosa",
   "BITD.PositionDesperate": "Disperata",
+  "BITD.DesperateXPReminder": "Segna 1 PE in",
   "BITD.EffectLimited": "Limitata",
   "BITD.EffectStandard": "Normale",
   "BITD.EffectGreat": "Superiore",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -209,6 +209,7 @@
   "BITD.PositionControlled": "Kontrolowana",
   "BITD.PositionRisky": "Ryzykowna",
   "BITD.PositionDesperate": "Desperacka",
+  "BITD.DesperateXPReminder": "Zaznacz 1 pd w",
   "BITD.EffectLimited": "Ograniczony",
   "BITD.EffectStandard": "Normalny",
   "BITD.EffectGreat": "Duży",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -213,6 +213,7 @@
   "BITD.PositionControlled": "Controlada",
   "BITD.PositionRisky": "Arriscada",
   "BITD.PositionDesperate": "Desesperada",
+  "BITD.DesperateXPReminder": "Marque 1 XP em",
   "BITD.EffectLimited": "Limitado",
   "BITD.EffectStandard": "Padrão",
   "BITD.EffectGreat": "Sensacional",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -213,6 +213,7 @@
 	"BITD.PositionControlled": "Controlada",
 	"BITD.PositionRisky": "Arriscada",
 	"BITD.PositionDesperate": "Desesperada",
+	"BITD.DesperateXPReminder": "Marque 1 XP em",
 	"BITD.EffectLimited": "Limitado",
 	"BITD.EffectStandard": "Padrão",
 	"BITD.EffectGreat": "Superior",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -211,6 +211,7 @@
   "BITD.PositionControlled": "Контролируемая",
   "BITD.PositionRisky": "Рискованная",
   "BITD.PositionDesperate": "Отчаянная",
+  "BITD.DesperateXPReminder": "Отметь 1 опыт в",
   "BITD.EffectLimited": "Низкая",
   "BITD.EffectStandard": "Средняя",
   "BITD.EffectGreat": "Высокая",

--- a/module/blades-helpers.js
+++ b/module/blades-helpers.js
@@ -201,6 +201,33 @@ export class BladesHelpers {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Returns the parent attribute key for a given action (skill) name.
+   * For example, "hunt" returns "insight", "skirmish" returns "prowess".
+   * Returns null if attribute_name is not a skill action.
+   *
+   * Used to determine which attribute XP track to mark when a desperate
+   * action roll is made (core rule: mark 1 XP in that action's attribute).
+   *
+   * @param {string} attribute_name
+   * @returns {string|null}
+   */
+  static getParentAttributeForAction(attribute_name) {
+    const attributes = game.model.Actor.character.attributes;
+
+    for (const att_name in attributes) {
+      for (const skill_name in attributes[att_name].skills) {
+        if (skill_name === attribute_name) {
+          return att_name;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /* -------------------------------------------- */
   static getProperCase(name) {
     return name.charAt(0).toUpperCase() + name.substr(1).toLowerCase();
   }

--- a/module/blades-roll.js
+++ b/module/blades-roll.js
@@ -145,7 +145,17 @@ async function showChatRollMessage(r, zeromode, attribute_name = "", position = 
         effect_localize = 'BITD.EffectStandard'
     }
 
-    result = await renderTemplate("systems/blades-in-the-dark/templates/chat/action-roll.html", {rolls: rolls, zeromode: zeromode, method: method, roll_status: roll_status, attribute_label: attribute_label, position: position, position_localize: position_localize, effect: effect, effect_localize: effect_localize, note: note, edge: edge});
+    // Desperate action rolls trigger the rule: mark 1 XP in the rolled attribute.
+    // Resolve the parent attribute label now so the template can display the reminder.
+    let desperate_xp_attribute_label = null;
+    if (position === "desperate") {
+      const parentAttribute = BladesHelpers.getParentAttributeForAction(attribute_name);
+      if (parentAttribute) {
+        desperate_xp_attribute_label = game.model.Actor.character.attributes[parentAttribute]?.label ?? null;
+      }
+    }
+
+    result = await renderTemplate("systems/blades-in-the-dark/templates/chat/action-roll.html", {rolls: rolls, zeromode: zeromode, method: method, roll_status: roll_status, attribute_label: attribute_label, position: position, position_localize: position_localize, effect: effect, effect_localize: effect_localize, note: note, edge: edge, desperate_xp_attribute_label: desperate_xp_attribute_label});
   }
   // Check for Resistance roll
   else if (BladesHelpers.isAttributeAttribute(attribute_name)) {

--- a/styles/blades.css
+++ b/styles/blades.css
@@ -1908,6 +1908,16 @@
   color: red;
 }
 
+/* Desperate action roll XP reminder — shown in chat when position is Desperate */
+.desperate-xp-reminder {
+  border-left: 3px solid #c8920a;
+  background-color: rgba(200, 146, 10, 0.1);
+  padding: 3px 6px;
+  margin: 4px 0;
+  font-size: 0.9em;
+  color: #c8920a;
+}
+
 /* Add Items Dialog */
 /* V11 legacy Dialog: scroll on the form wrapper */
 .items-to-add {

--- a/templates/chat/action-roll.html
+++ b/templates/chat/action-roll.html
@@ -56,6 +56,12 @@
 	  {{/if}}
   </div>
   
+  {{#if desperate_xp_attribute_label}}
+    <div class="description desperate-xp-reminder">
+      <p><strong>{{localize "BITD.DesperateXPReminder"}}</strong> {{localize desperate_xp_attribute_label}}</p>
+    </div>
+  {{/if}}
+
   {{#if note}}
     <em>{{note}}</em>
   {{/if}}


### PR DESCRIPTION
When a player makes a desperate action roll, display a reminder in the chat card to mark 1 XP in that action's attribute (Insight, Prowess, or Resolve). Page 48.

Changes:
- Add BladesHelpers.getParentAttributeForAction() to map actions to attributes
- Pass desperate_xp_attribute_label to action-roll template when desperate
- Render reminder block in action-roll.html with BITD.DesperateXPReminder
- Add .desperate-xp-reminder CSS with amber left-border styling
- Add BITD.DesperateXPReminder localization key to all 9 supported languages